### PR TITLE
Fix: Improve error message for missing package.json

### DIFF
--- a/src/packages.test.ts
+++ b/src/packages.test.ts
@@ -1,4 +1,5 @@
 import packageInfo from 'package-json';
+import { readPackage } from 'read-pkg';
 import { describe, expect, it, vi } from 'vitest';
 import { getCurrentProjectDependencies, getPackageInfo, getRepoUrl } from './packages.js';
 
@@ -49,6 +50,13 @@ describe('packages', () => {
       };
 
       expect(await getCurrentProjectDependencies(true)).toEqual(expected);
+    });
+
+    it('should throw custom error if package.json is not found', async () => {
+      (readPackage as vi.Mock).mockRejectedValueOnce({ code: 'ENOENT' });
+      await expect(getCurrentProjectDependencies()).rejects.toThrowError(
+        'No package.json file found in the current directory. Please ensure you are in the correct directory or create a package.json file.',
+      );
     });
   });
 });

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -2,7 +2,17 @@ import packageInfo, { FullMetadata, FullVersion } from 'package-json';
 import { readPackage } from 'read-pkg';
 
 export async function getCurrentProjectDependencies(searchSubDeps = false) {
-  const packageJson = await readPackage();
+  let packageJson;
+  try {
+    packageJson = await readPackage();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        'No package.json file found in the current directory. Please ensure you are in the correct directory or create a package.json file.',
+      );
+    }
+    throw error;
+  }
 
   let dependencies = {
     ...packageJson.dependencies,


### PR DESCRIPTION
When the `package.json` file is not found in the current directory, the tool now throws a more user-friendly error message:
"No package.json file found in the current directory. Please ensure you are in the correct directory or create a package.json file."

This replaces the generic error that was previously thrown by the `read-pkg` library.

A new test case has been added to `src/packages.test.ts` to verify that this custom error message is correctly thrown.

Additionally, formatting in `src/packages.test.ts` has been updated to ensure correct newline placement around import statements as per project Prettier configuration.